### PR TITLE
Update spec for emacs pre-release 29.0.92 from 06/15/2023

### DIFF
--- a/emacs.spec
+++ b/emacs.spec
@@ -1,8 +1,8 @@
 %global _hardened_build 1
 
-%global commit      a27b0f7f307ccf54fd5910a0655bd72b23e69fcf
+%global commit      a24e9e3fee59435422af0473b7ec585de2c13b4e
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
-%global commit_date 20230326
+%global commit_date 20230615
 %global gitrel      .%{commit_date}.git%{shortcommit}
 
 # disable these for now until .pdmp is fixed
@@ -13,7 +13,7 @@
 Summary:       GNU Emacs text editor
 Name:          emacs
 Epoch:         1
-Version:       29.0.50
+Version:       29.0.92
 Release:       1%{gitrel}%{?dist}
 License:       GPLv3+ and CC0-1.0
 URL:           http://www.gnu.org/software/emacs/
@@ -410,7 +410,7 @@ cat el-*-files common-lisp-dir-files > el-filelist
 rm %{buildroot}%{_datadir}/icons/hicolor/scalable/mimetypes/emacs-document23.svg
 
 # remove debug info
-rm -rf %{buildroot}%{prefix}/lib/debug/usr/libexec/emacs/28.0.50
+rm -rf %{buildroot}%{prefix}/lib/debug/usr/libexec/emacs/${version}
 
 %preun
 %{_sbindir}/alternatives --remove emacs %{_bindir}/emacs-%{version}


### PR DESCRIPTION
Provides a bump on building emacs pre-release tag 29.0.92 (See [emacs mirror tags](https://github.com/emacs-mirror/emacs/releases/tag/emacs-29.0.92)) that builds fine on FC37 and FC38. Main reason for the bump is that the previous mirror commit `a27b0f7f307ccf54fd5910a0655bd72b23e69fcf` is not existing anymore.